### PR TITLE
Links from composition to source go directly to the relevant folio

### DIFF
--- a/diamm/serializers/website/composition.py
+++ b/diamm/serializers/website/composition.py
@@ -18,15 +18,17 @@ class CompositionSourceSerializer(ContextSerializer):
     )
 
     has_images = serpy.MethodField()
-
     public_images = serpy.BoolField(
         attr="source.public_images"
     )
 
     def get_url(self, obj):
-        return reverse('source-detail',
+        url = reverse('source-detail',
                        kwargs={"pk": obj.source.pk},
                        request=self.context['request'])
+        if self.get_has_images(obj):
+            url += "#tab=images&folio={0}".format(obj.folio_start)
+        return url
 
     def get_has_images(self,obj):
         if obj.pages.count() > 0:

--- a/diamm/static/javascripts/lib/goToPage.js
+++ b/diamm/static/javascripts/lib/goToPage.js
@@ -1,27 +1,18 @@
-var goToPage = function()
-{
-    var _onFolioClick = function (pageName)
+var Page = function (params) {
+    var goToPage = function(pageName)
     {
-        return function()
-        {
-            activeTabPanel = document.querySelector(".front");
-            activeTabPanel.classList.remove("front");
-            newActiveTabPanel = document.querySelector("#images");
-            newActiveTabPanel.classList.add("front");
+        activeTabPanel = document.querySelector('.front');
+        activeTabPanel.classList.remove('front');
+        newActiveTabPanel = document.querySelector('#images');
+        newActiveTabPanel.classList.add('front');
 
-            var diva_instance = $('#diva-wrapper').data('diva');
-            diva_instance.gotoPageByName(pageName);
-            // This is to make sure the diva viewer resizes on tab change
-            // Will be a non-issue in diva 5
-            window.dispatchEvent(new Event("resize"));
-        }
+        var diva_instance = $('#diva-wrapper').data('diva');
+        diva_instance.gotoPageByName(pageName);
+        // This is to make sure the diva viewer resizes on tab change
+        // Will be a non-issue in diva 5
+        window.dispatchEvent(new Event('resize'));
     }
 
-    var folio_links = document.querySelectorAll('.folio-link');
-    for (var i=0, len=folio_links.length; i < len; i++)
-    {
-        page = folio_links[i].dataset.page;
-        folio_links[i].addEventListener("click", _onFolioClick(page) )
-    }
-
+    if (params['folio'])
+        goToPage(params['folio']);
 }

--- a/diamm/static/javascripts/lib/goToPage.js
+++ b/diamm/static/javascripts/lib/goToPage.js
@@ -1,18 +1,33 @@
-var Page = function (params) {
+var Page = function (divaInstance)
+{
     var goToPage = function(pageName)
     {
         activeTabPanel = document.querySelector('.front');
-        activeTabPanel.classList.remove('front');
+        if (activeTabPanel)
+            activeTabPanel.classList.remove('front');
         newActiveTabPanel = document.querySelector('#images');
         newActiveTabPanel.classList.add('front');
 
-        var diva_instance = $('#diva-wrapper').data('diva');
-        diva_instance.gotoPageByName(pageName);
+        divaInstance.gotoPageByName(pageName);
         // This is to make sure the diva viewer resizes on tab change
         // Will be a non-issue in diva 5
         window.dispatchEvent(new Event('resize'));
     }
 
-    if (params['folio'])
-        goToPage(params['folio']);
+    return function (params) {
+        if (params['folio'])
+        {
+            if (!divaInstance.isReady())
+            {
+                var handle = diva.Events.subscribe(
+                    'ViewerDidLoad',
+                    function ()
+                    {
+                        goToPage(params['folio']);
+                        diva.Events.unsubscribe(handle);
+                    });
+            }
+            goToPage(params['folio']);
+        }
+    };
 }

--- a/diamm/static/javascripts/lib/goToTab.js
+++ b/diamm/static/javascripts/lib/goToTab.js
@@ -14,6 +14,9 @@ var Tab = function (params) {
         window.dispatchEvent(new Event('resize'));
     };
 
-    if (params['tab'])
-            goToTab(params['tab']);
+    if (params['tab']) {
+        goToTab(params['tab']);
+    } else {
+        goToTab('details');
+    }
 };

--- a/diamm/static/javascripts/lib/goToTab.js
+++ b/diamm/static/javascripts/lib/goToTab.js
@@ -1,0 +1,19 @@
+var Tab = function (params) {
+    var goToTab = function (tabHash)
+    {
+        var activeTabPanel = document.querySelector('.front');
+        if (activeTabPanel)
+        {
+            activeTabPanel.classList.remove('front');
+        }
+        var newActiveTabPanel = document.querySelector('#'+tabHash);
+        newActiveTabPanel.classList.add('front');
+
+        // This is to make sure the diva viewer resizers on tab change
+        // Will be a non-issue in diva 5
+        window.dispatchEvent(new Event('resize'));
+    };
+
+    if (params['tab'])
+            goToTab(params['tab']);
+};

--- a/diamm/static/javascripts/lib/tabs.js
+++ b/diamm/static/javascripts/lib/tabs.js
@@ -1,76 +1,31 @@
-(function($)
-{
-    var Tabs = function (element, options)
+function Hash () {
+    console.log("Hash has been initialized");
+    var that = this;
+
+    this.callbacks = arguments;
+
+    var getHashParams = function ()
     {
-        var parentObject = $(element);
+        var hash = window.location.hash.substr(1).split('&');
 
-        var defaults = {
-            tabsID: "tabs",                   // id of the parent tab block
-            tabClass: "tab",                  // class of the <li> for each tab.
-            tabContainerID: "tab-container",  // ID of the tab container block
-            tabPanelClass: "tab-panel",       // class of the div for each tab panel.
-            tabCallbacks: {}                  // a hash of callbacks to call when a tab panel is switched. Format: {hash: function}
-        };
-
-        var settings = $.extend({}, defaults, options);
-
-        var init = function ()
+        var params = {};
+        for (var i = 0, hlen = hash.length; i < hlen; i++)
         {
-            console.log('tab init called');
-            var tabParent = document.getElementById(settings.tabsID);
-            var tabs = tabParent.querySelectorAll("a.tab"),
-                i = tabs.length;
-
-            while(i--)
-            {
-                var tab = tabs[i];
-                handleClick(tab);
-                if (tab.classList.contains('active'))
-                {
-                    gotoTab(tab.hash);
-                }
-            }
-        };
-
-        var handleClick = function (tab)
-        {
-            tab.addEventListener('click', function(event)
-            {
-                event.preventDefault();
-                gotoTab(tab.hash);
-            });
-        };
-
-        var gotoTab = function (tabHash)
-        {
-            var activeTabPanel = document.querySelector('.front');
-            if (activeTabPanel)
-            {
-                activeTabPanel.classList.remove('front');
-            }
-            var newActiveTabPanel = document.querySelector(tabHash);
-            newActiveTabPanel.classList.add('front');
-
-            if (settings.tabCallbacks.hasOwnProperty(tabHash))
-            {
-                settings.tabCallbacks[tabHash]();
-            }
-            // This is to make sure the diva viewer resizers on tab change
-            // Will be a non-issue in diva 5
-            window.dispatchEvent(new Event("resize"));
-        };
-
-        init();
-    };
-
-    $.fn.tabs = function (options)
-    {
-        return this.each(function ()
-        {
-            var tabContainer = $(this);
-
-            var tabs = new Tabs(this, options);
-            tabContainer.data('tabs', tabs);
-        })
+            h = hash[i].split("=");
+            params[h[0]] = h[1];
+        }
+        return params;
     }
-})(jQuery);
+
+    var onHashChange = function()
+    {
+        params = getHashParams();
+        for (var i = 0, clen = this.callbacks.length; i < clen; i++)
+        {
+            that.callbacks[i](params);
+        }
+    }
+
+    onHashChange();
+    window.onhashchange = onHashChange;
+}

--- a/diamm/templates/website/source/source_detail.jinja2
+++ b/diamm/templates/website/source/source_detail.jinja2
@@ -107,9 +107,10 @@
                         enableIIIFPageData: true,
                         enableIIIFStructure: true
                 });
+                divaObj = $("#diva-wrapper").data('diva');
             }
             //Registers functions that will be called when the fragment identifier is changed
-            Hash(Tab, Page);
+            Hash(Tab, Page(divaObj));
         };
     </script>
 {% endblock %}

--- a/diamm/templates/website/source/source_detail.jinja2
+++ b/diamm/templates/website/source/source_detail.jinja2
@@ -31,28 +31,28 @@
     <div class="row">
         <div id="tabs" class="sixteen columns source-tabs">
             <ul>
-                <li><a class="tab active" href="#details">Details</a></li>
+                <li><a class="tab active" href="#tab=details">Details</a></li>
 
                 {% if content.inventory or content.uninventoried %}
-                <li><a class="tab" href="#inventory">Inventory</a></li>
+                <li><a class="tab" href="#tab=inventory">Inventory</a></li>
                 {% endif %}
 
                 {% if content.public_images and request.user.is_authenticated() %}
-                    <li><a class="tab" href="#images">Images</a></li>
+                    <li><a class="tab" href="#tab=images">Images</a></li>
                 {% elif content.public_images and request.user.is_authenticated() == False %}
                     <li><span class="tab">Images (<a href="{{ url('login') }}?next={{ request.get_full_path() }}">Log in</a> to view)</span></li>
                 {% endif %}
 
                 {% if content.sets %}
-                    <li><a class="tab" href="#sets">Sets</a></li>
+                    <li><a class="tab" href="#tab=sets">Sets</a></li>
                 {% endif %}
 
                 {% if content.catalogue_entries %}
-                <li><a class="tab" href="#catalogue">Catalogue Entries</a></li>
+                <li><a class="tab" href="#tab=catalogue">Catalogue Entries</a></li>
                 {% endif %}
 
                 {% if content.bibliography %}
-                <li><a class="tab" href="#bibliography">Bibliography</a></li>
+                <li><a class="tab" href="#tab=bibliography">Bibliography</a></li>
                 {% endif %}
             </ul>
         </div>
@@ -93,11 +93,11 @@
     <script src="{{ static('javascripts/lib/diva.js/js/utils.js') }}" type="application/javascript"></script>
     <script src="{{ static('javascripts/lib/iiif-structure.js') }}" type="application/javascript"></script>
     <script src="{{ static('javascripts/lib/tabs.js') }}" type="application/javascript"></script>
+    <script src="{{ static('javascripts/lib/goToTab.js') }}" type="application/javascript"></script>
     <script src="{{ static('javascripts/lib/goToPage.js') }}" type="application/javascript"></script>
     <script type="application/javascript">
         window.onload = function()
         {
-            $("#tabs").tabs()
             var divaObj = $("#diva-wrapper").data('diva');
             if (!divaObj)
             {
@@ -108,7 +108,8 @@
                         enableIIIFStructure: true
                 });
             }
-            goToPage();
+            //Registers functions that will be called when the fragment identifier is changed
+            Hash(Tab, Page);
         };
     </script>
 {% endblock %}

--- a/diamm/templates/website/source/source_inventory_block.jinja2
+++ b/diamm/templates/website/source/source_inventory_block.jinja2
@@ -7,7 +7,7 @@
             <dt class="source-inventory-header">
 
                 {% if item.folio_start %}
-                <a href="#" class="folio-link" data-page="{{item.folio_start}}" >{{ item.folio_start }}
+                <a href="#tab=images&folio={{ item.folio_start }}" class="folio-link">{{ item.folio_start }}
                         {% if item.folio_end %}
                             &ndash;{{ item.folio_end }}
                         {% endif %}</a>:
@@ -78,7 +78,7 @@
                     {% for item in composer.inventory %}
                         <li>
                             {%- if item.folio_start_s %}
-                                <a href="#" class="folio-link" data-page="{{ item.folio_start_s }}">{{ item.folio_start_s }}
+                            <a href="#tab=images&folio={{ item.folio_start_s }}" class="folio-link">{{ item.folio_start_s }}
                                 {%- if item.folio_end_s != item.folio_start_s -%}&ndash;{{ item.folio_end_s }}: {%- endif -%}
                                 </a>
                             {% endif -%}

--- a/diamm/views/website/composition.py
+++ b/diamm/views/website/composition.py
@@ -17,9 +17,3 @@ class CompositionDetail(generics.RetrieveAPIView):
     renderer_classes = (HTMLRenderer, renderers.JSONRenderer)
     serializer_class = CompositionDetailSerializer
     queryset = Composition.objects.all()
-
-
-
-
-
-


### PR DESCRIPTION
Refs #136

When users are on a _composition_ page and they follow a link to a _source with images_ they expect to be taken directly to the folio that contains that _composition_.
