### PR TITLE
Fixed: Update diva.js to 5.1.0

### DIFF
--- a/diamm/static/apps/package.json
+++ b/diamm/static/apps/package.json
@@ -24,7 +24,7 @@
     "babel-loader": "^6.2.8",
     "classnames": "^2.2.5",
     "dateformat": "^2.0.0",
-    "diva.js": "^5.0.4",
+    "diva.js": "^5.1.0",
     "exports-loader": "^0.6.3",
     "history": "^3.2.1",
     "immutable": "^3.8.1",


### PR DESCRIPTION
This version of diva adds preliminary support for multiple images per canvas.