### PR TITLE
Fixed: Crashes when adding an item

### DIFF
--- a/diamm/signals/item_signals.py
+++ b/diamm/signals/item_signals.py
@@ -11,11 +11,13 @@ from diamm.serializers.search.item import ItemSearchSerializer
 def index_item(sender, instance, created, **kwargs):
     solr_index(ItemSearchSerializer, instance)
     solr_index(SourceSearchSerializer, instance.source)
-    solr_index(CompositionSearchSerializer, instance.composition)
+    if instance.composition:
+        solr_index(CompositionSearchSerializer, instance.composition)
 
 
 @receiver(post_delete, sender=Item)
 def delete_item(sender, instance, **kwargs):
     solr_delete(instance)
     solr_index(SourceSearchSerializer, instance.source)
-    solr_index(CompositionSearchSerializer, instance.composition)
+    if instance.composition:
+        solr_index(CompositionSearchSerializer, instance.composition)


### PR DESCRIPTION
If there was no composition attached to an item but it was saved, the app would crash when it came time to try and index it. This commit adds a check to see if the composition is none before indexing.

Fixes #208